### PR TITLE
Add compatibility for parent categories in Discourse Category Headers

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -35,6 +35,7 @@ $nested-list: (
         .category-title-name .d-icon-lock:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
           display: none;
         }
+      }
     }
 
     @else {

--- a/common/common.scss
+++ b/common/common.scss
@@ -32,7 +32,9 @@ $nested-list: (
             display: none;
           }
         }
-      }
+        .category-title-name .d-icon-lock:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
+          display: none;
+        }
     }
 
     @else {
@@ -48,6 +50,9 @@ $nested-list: (
         .d-icon-lock {
           display: none;
         }
+      }
+      .category-title-name .d-icon-lock:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
+          display: none;
       }
     }
   }


### PR DESCRIPTION
Adds a :has() pseudo class to specifically target parent categories in Category headers.

This is hopefully the last of these!