### PR TITLE
Add feature: compatibility with alternative lock icons

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -35,6 +35,7 @@ $nested-list: (
         .category-title-name .d-icon-lock:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
           display: none;
         }
+      }
     }
 
     @else {

--- a/common/common.scss
+++ b/common/common.scss
@@ -32,7 +32,9 @@ $nested-list: (
             display: none;
           }
         }
-      }
+        .category-title-name .d-icon-lock:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
+          display: none;
+        }
     }
 
     @else {
@@ -48,6 +50,9 @@ $nested-list: (
         .d-icon-lock {
           display: none;
         }
+      }
+      .category-title-name .d-icon-lock:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
+          display: none;
       }
     }
   }

--- a/common/common.scss
+++ b/common/common.scss
@@ -28,11 +28,11 @@ $nested-list: (
         [href="/chat/c/#{$lock-icon}/#{$iconID}"],
         [href="/c/#{$lock-icon}/#{$iconID}"], 
         .category-#{$lock-icon-class} .category-title-name {
-          .d-icon-lock {
+          .d-icon-#{$alternative_category_lock_icon} {
             display: none;
           }
         }
-        .category-title-name .d-icon-lock:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
+        .category-title-name .d-icon-#{$alternative_category_lock_icon}:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
           display: none;
         }
       }
@@ -48,11 +48,11 @@ $nested-list: (
       [href="/chat/c/#{$lock-icon}/#{$iconID}"],
       [href="/c/#{$lock-icon}/#{$iconID}"],
       .category-#{$lock-icon-class} .category-title-name {
-        .d-icon-lock {
+        .d-icon-#{$alternative_category_lock_icon} {
           display: none;
         }
       }
-      .category-title-name .d-icon-lock:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
+      .category-title-name .d-icon-#{$alternative_category_lock_icon}:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
           display: none;
       }
     }
@@ -72,7 +72,7 @@ $nested-list: (
       [href^="/chat/c/"],
       [href^="/c/"],
       .category-title-name {
-        .d-icon-lock {
+        .d-icon-#{$alternative_category_lock_icon} {
           display: none;
         }
       }
@@ -89,7 +89,7 @@ $nested-list: (
     [href^="/chat/c/"],
     [href^="/c/"],
     .category-title-name {
-      .d-icon-lock {
+      .d-icon-#{$alternative_category_lock_icon} {
         display: none;
       }
     }

--- a/settings.yaml
+++ b/settings.yaml
@@ -11,6 +11,6 @@ show_lock_icons_for_staff:
     en: "Disable this if you want the lock badge icon to be hidden for staff as well as regular users."
 
 alternative_category_lock_icon:
-  default: ""
+  default: "lock"
   description:
-    en: "If you are using an alternative lock icon, put the FontAwesome 5 icon name here"
+    en: "If you are using an alternative lock icon, change this to the FontAwesome 5 icon name here"

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,3 +9,8 @@ show_lock_icons_for_staff:
   default: true
   description:
     en: "Disable this if you want the lock badge icon to be hidden for staff as well as regular users."
+
+alternative_category_lock_icon:
+  default: ""
+  description:
+    en: "If you are using an alternative lock icon, put the FontAwesome 5 icon name here"


### PR DESCRIPTION
Adds compatibility with the alternative lock icons from github.com/discourse/discourse-category-icons

Also includes a minor buff to the Discourse Category Headers compatibility