### PR TITLE
DEV: update for new category lock icon alias

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -25,14 +25,15 @@ $nested-list: (
         .search-menu .results .restricted[data-category-id="#{$iconID}"],
         .badge-category__wrapper [data-category-id="#{$iconID}"],
         .category-drop [data-value="#{$iconID}"] .restricted,
-        [href="/chat/c/#{$lock-icon}/#{$iconID}"],
-        [href="/c/#{$lock-icon}/#{$iconID}"], 
+        [href^="/chat/c/#{$lock-icon}/#{$iconID}"],
+        [href^="/c/#{$lock-icon}/#{$iconID}"], 
         .category-#{$lock-icon-class} .category-title-name {
-          .d-icon-#{$alternative_category_lock_icon} {
+          .d-icon-lock,
+          [class*="d-icon-category.restricted"] {
             display: none;
           }
         }
-        .category-title-name .d-icon-#{$alternative_category_lock_icon}:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
+        .category-title-name [class*="d-icon-category.restricted"]:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
           display: none;
         }
       }
@@ -45,14 +46,15 @@ $nested-list: (
       .search-menu .results .restricted[data-category-id="#{$iconID}"],
       .badge-category__wrapper [data-category-id="#{$iconID}"],
       .category-drop [data-value="#{$iconID}"] .restricted,
-      [href="/chat/c/#{$lock-icon}/#{$iconID}"],
-      [href="/c/#{$lock-icon}/#{$iconID}"],
+      [href^="/chat/c/#{$lock-icon}/#{$iconID}"],
+      [href^="/c/#{$lock-icon}/#{$iconID}"],
       .category-#{$lock-icon-class} .category-title-name {
-        .d-icon-#{$alternative_category_lock_icon} {
+         .d-icon-lock,
+        [class*="d-icon-category.restricted"] {
           display: none;
         }
       }
-      .category-title-name .d-icon-#{$alternative_category_lock_icon}:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
+      .category-title-name [class*="d-icon-category.restricted"]:has(+ .parent-box-link[href="/c/#{$lock-icon}/#{$iconID}"]) {
           display: none;
       }
     }
@@ -72,7 +74,8 @@ $nested-list: (
       [href^="/chat/c/"],
       [href^="/c/"],
       .category-title-name {
-        .d-icon-#{$alternative_category_lock_icon} {
+         .d-icon-lock,
+        [class*="d-icon-category.restricted"] {
           display: none;
         }
       }
@@ -89,7 +92,8 @@ $nested-list: (
     [href^="/chat/c/"],
     [href^="/c/"],
     .category-title-name {
-      .d-icon-#{$alternative_category_lock_icon} {
+       .d-icon-lock,
+      [class*="d-icon-category.restricted"] {
         display: none;
       }
     }

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,8 +9,3 @@ show_lock_icons_for_staff:
   default: true
   description:
     en: "Disable this if you want the lock badge icon to be hidden for staff as well as regular users."
-
-alternative_category_lock_icon:
-  default: "lock"
-  description:
-    en: "If you are using an alternative lock icon, change this to the FontAwesome 6 icon name here"


### PR DESCRIPTION
This updates to match the change in https://github.com/discourse/discourse/commit/92c9d43b9a69149b10331d9d36179a9d7d48c5a0

The `alternative_category_lock_icon` setting is no longer necessary because category lock icons will always be `d-icon-category.restricted` when replaced using our [icon replacement API](https://meta.discourse.org/t/change-icons-globally/87751).

The `.d-icon-lock` remains for older Discourse sites and chat channels.